### PR TITLE
Add ability to generate docs only for specific route uri prefix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "justraviga/laravel-request-docs",
+    "name": "rakutentech/laravel-request-docs",
     "description": "Automatically generate Laravel docs from request rules, controllers and routes",
     "keywords": [
         "rakutentech",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "rakutentech/laravel-request-docs",
+    "name": "justraviga/laravel-request-docs",
     "description": "Automatically generate Laravel docs from request rules, controllers and routes",
     "keywords": [
         "rakutentech",

--- a/config/request-docs.php
+++ b/config/request-docs.php
@@ -22,6 +22,9 @@ return [
      */
     'sort_by' => 'default',
 
+    //Use only routes where ->uri start with next string Using Str::startWith( . e.g. - /api/mobile
+    'only_route_uri_start_with' => '',
+
     'hide_matching' => [
         "#^telescope#",
         "#^docs#",


### PR DESCRIPTION
I needed that to generate route only for `/api/mobile` 
But existing `hide_matching` analyzes all routes anyway