### PR TITLE
Route comments using Attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,25 @@ Example of using it in controller
     {
 ```
 
+## Comment using attributes (>= php 8)
+Extra comments can also be added to controller methods using attributes. Currently supported attributes are
+- `Rakutentech\LaravelRequestDocs\Attributes\RouteDescription`
+- `Rakutentech\LaravelRequestDocs\Attributes\RouteDeprecated`
+
+```php
+#[RouteDescription('Title', 'Description')]
+public function create(FooCreateRequest $request)
+{
+    ...
+}
+
+#[RouteDeprecated('With comment')]
+public function oldEndpoint()
+{
+    ...
+}
+```
+
 # Testing
 
 ```bash

--- a/src/Attributes/RouteAttribute.php
+++ b/src/Attributes/RouteAttribute.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rakutentech\LaravelRequestDocs\Attributes;
+
+abstract class RouteAttribute
+{
+
+    abstract public function toMarkdown(): string;
+
+}

--- a/src/Attributes/RouteDeprecated.php
+++ b/src/Attributes/RouteDeprecated.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rakutentech\LaravelRequestDocs\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class RouteDeprecated extends RouteAttribute
+{
+    public function __construct(private string $comment = '')
+    {
+
+    }
+
+    public function toMarkdown(): string
+    {
+        return '**Deprecated!** ' . $this->comment;
+    }
+}

--- a/src/Attributes/RouteDeprecated.php
+++ b/src/Attributes/RouteDeprecated.php
@@ -14,6 +14,6 @@ class RouteDeprecated extends RouteAttribute
 
     public function toMarkdown(): string
     {
-        return '**Deprecated!** ' . $this->comment;
+        return '**Deprecated!**' . (strlen($this->comment > 0) ? ' ' . $this->comment : '');
     }
 }

--- a/src/Attributes/RouteDescription.php
+++ b/src/Attributes/RouteDescription.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rakutentech\LaravelRequestDocs\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class RouteDescription extends RouteAttribute
+{
+
+    public function __construct(public string $title, public string $description)
+    {
+
+    }
+
+    public function toMarkdown(): string
+    {
+        return "# " . $this->title . "\n" . $this->description;
+    }
+
+}

--- a/src/LaravelRequestDocs.php
+++ b/src/LaravelRequestDocs.php
@@ -87,10 +87,13 @@ class LaravelRequestDocs
                     }
                 }
 
+                $middlewares = isset($route->action['middleware'])
+                    ? (!is_array($route->action['middleware']) ? [$route->action['middleware']] : $route->action['middleware'])
+                    : [];
                 $controllersInfo[] = [
                     'uri'                   => $route->uri,
                     'methods'               => $route->methods,
-                    'middlewares'           => !is_array($route->action['middleware']) ? [$route->action['middleware']] : $route->action['middleware'],
+                    'middlewares'           => $middlewares,
                     'controller'            => $controllerName,
                     'controller_full_path'  => $controllerFullPath,
                     'method'                => $method,

--- a/tests/RouteAttributeTest.php/RouteAttributeTest.php
+++ b/tests/RouteAttributeTest.php/RouteAttributeTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rakutentech\LaravelRequestDocs\Tests\RouteAttributeTest;
+
+use Illuminate\Support\Facades\Route;
+use Rakutentech\LaravelRequestDocs\LaravelRequestDocs;
+use Rakutentech\LaravelRequestDocs\Tests\TestCase;
+use Rakutentech\LaravelRequestDocs\Tests\TestControllers\AttributesController;
+
+/**
+ * @requires PHP >= 8.0
+ */
+class RouteAttributeTest extends TestCase
+{
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+
+        Route::get('lrd/tests/attributes', [AttributesController::class, 'first']);
+        Route::get('lrd/tests/attributes/deprecated', [AttributesController::class, 'deprecated']);
+        Route::get('lrd/tests/attributes/deprecated/with-comment', [AttributesController::class, 'alsoDeprecated']);
+    }
+
+    /** @test */
+    public function it_can_build_comment_using_attribute()
+    {
+        $info = $this->getControllerInfoByUri('lrd/tests/attributes');
+        $this->assertEquals("# Title\nDescription", $info['docBlock']);
+    }
+
+    /** @test */
+    public function it_can_build_deprecated_comment_using_attribute()
+    {
+        $info = $this->getControllerInfoByUri('lrd/tests/attributes/deprecated');
+        $this->assertEquals("**Deprecated!**", $info['docBlock']);
+
+        $info = $this->getControllerInfoByUri('lrd/tests/attributes/deprecated/with-comment');
+        $this->assertEquals("**Deprecated!** With comment", $info['docBlock']);
+    }
+
+}

--- a/tests/RouteAttributeTest.php/RouteAttributeTest.php
+++ b/tests/RouteAttributeTest.php/RouteAttributeTest.php
@@ -17,7 +17,6 @@ class RouteAttributeTest extends TestCase
     {
         parent::setUp();
 
-
         Route::get('lrd/tests/attributes', [AttributesController::class, 'first']);
         Route::get('lrd/tests/attributes/deprecated', [AttributesController::class, 'deprecated']);
         Route::get('lrd/tests/attributes/deprecated/with-comment', [AttributesController::class, 'alsoDeprecated']);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,15 +2,19 @@
 
 namespace Rakutentech\LaravelRequestDocs\Tests;
 
-use Illuminate\Database\Eloquent\Factories\Factory;
 use Orchestra\Testbench\TestCase as Orchestra;
+use Rakutentech\LaravelRequestDocs\LaravelRequestDocs;
 use Rakutentech\LaravelRequestDocs\LaravelRequestDocsServiceProvider;
 
 class TestCase extends Orchestra
 {
+
+    protected LaravelRequestDocs $lrd;
+
     public function setUp(): void
     {
         parent::setUp();
+        $this->lrd = new LaravelRequestDocs();
     }
 
     protected function getPackageProviders($app)
@@ -23,5 +27,12 @@ class TestCase extends Orchestra
     public function getEnvironmentSetUp($app)
     {
         config()->set('database.default', 'testing');
+    }
+
+    protected function getControllerInfoByUri(string $uri): ?array
+    {
+        return collect($this->lrd->getControllersInfo())
+            ->where('uri', '=', $uri)
+            ->first();
     }
 }

--- a/tests/TestControllers/AttributesController.php
+++ b/tests/TestControllers/AttributesController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rakutentech\LaravelRequestDocs\Tests\TestControllers;
+
+use Rakutentech\LaravelRequestDocs\Attributes\RouteDeprecated;
+use Rakutentech\LaravelRequestDocs\Attributes\RouteDescription;
+
+class AttributesController
+{
+
+    #[RouteDescription('Title', 'Description')]
+    public function first()
+    {
+        return 1;
+    }
+
+    #[RouteDeprecated()]
+    public function deprecated()
+    {
+        return 1;
+    }
+
+    #[RouteDeprecated('With comment')]
+    public function alsoDeprecated()
+    {
+        return 1;
+    }
+
+}


### PR DESCRIPTION
This PR adds functionality that requires php >= 8. Support for php 7.4 should still be okey.

Adding extra comments to a route using annotations in doc blocks can get somewhat bloated, and isn't very structured. It leaves it to every developer as to how to structure the comment.

By adding structured attributes it makes it a little easier to enforce a title and a description to any endpoint comment. Also, attributes could in the future be used to set other details about the route.

```php
#[RouteDescription('Title', 'Description')]
public function create(FooCreateRequest $request)
{
    ...
}
```

I have also added some tests to this. Since there were no tests to begin with there was nothing to build on. And there are no specific tests for the core functionality. The tests I added naturally require PHP 8. I highly recommend adding a workflow to the repo and running the tests on all the officially supported PHP versions and platforms.

I have not tested this in php 7.4. I'd be great if someone could help me with that.

Also the template might be updated to better show these comments (IMHO it's a little small). Future PRs could also expand on the RouteDeprecated attribute and mark that in the generated docs with something more than just a markdown comment (some icon or color or whatever could be cool). 