### PR TITLE
Custom param rules and make lrd documents available for all route methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,26 @@ Example of using it in controller
     {
 ```
 
+# Custom Params
+
+You write extra params with rules with @QAparam comment line
+
+```php
+    /**
+     * @QAparam search string
+     */
+    public function index(MyIndexRequest $request): Resource
+    {
+```
+
+```php
+    /**
+     * @QAparam search string nullable max:32
+     */
+    public function index(MyIndexRequest $request): Resource
+    {
+```
+
 # Testing
 
 ```bash

--- a/src/LaravelRequestDocs.php
+++ b/src/LaravelRequestDocs.php
@@ -112,6 +112,7 @@ class LaravelRequestDocs
             $method           = $controllerInfo['method'];
             $reflectionMethod = new ReflectionMethod($controller, $method);
             $params           = $reflectionMethod->getParameters();
+            $customRules = $this->customParamsDocComment($reflectionMethod->getDocComment());
 
             foreach ($params as $param) {
                 if (!$param->getType()) {
@@ -141,6 +142,11 @@ class LaravelRequestDocs
                     }
                     $controllersInfo[$index]['docBlock'] = $this->lrdDocComment($reflectionMethod->getDocComment());
                 }
+
+                $controllersInfo[$index]['rules'] = array_merge(
+                    $controllersInfo[$index]['rules'] ?? [],
+                    $customRules,
+                );
             }
         }
         return $controllersInfo;
@@ -230,5 +236,24 @@ class LaravelRequestDocs
             })->toArray();
 
         return $rules;
+    }
+
+    private function customParamsDocComment($docComment): array
+    {
+        $params = [];
+
+        foreach (explode("\n", $docComment) as $comment) {
+            if ( Str::contains($comment, '@QAparam') ) {
+                $comment = trim(Str::replace(['@QAparam', '*'], '', $comment));
+
+                $comment = explode(' ', $comment);
+
+                if (count($comment) > 0) {
+                    $params[$comment[0]] = array_values(array_filter($comment, fn($item) => $item != $comment[0]));
+                }
+            }
+        }
+
+        return $params;
     }
 }

--- a/src/LaravelRequestDocs.php
+++ b/src/LaravelRequestDocs.php
@@ -140,8 +140,9 @@ class LaravelRequestDocs
                             throw $e;
                         }
                     }
-                    $controllersInfo[$index]['docBlock'] = $this->lrdDocComment($reflectionMethod->getDocComment());
                 }
+
+                $controllersInfo[$index]['docBlock'] = $this->lrdDocComment($reflectionMethod->getDocComment());
 
                 $controllersInfo[$index]['rules'] = array_merge(
                     $controllersInfo[$index]['rules'] ?? [],


### PR DESCRIPTION
Hey there, 

I was working on my project and I needed some custom params to document my api, there wasn't any option so I implemented this idea, now we can add custom params in our controller method document.

Also we could not put custom lrd documents on methods that have not the request class, so I move it after the if statement.

Thanks for this amazing package.