### PR TITLE
fix: method without params documents not shown

### DIFF
--- a/src/LaravelRequestDocs.php
+++ b/src/LaravelRequestDocs.php
@@ -147,13 +147,14 @@ class LaravelRequestDocs
                     }
                 }
 
-                $controllersInfo[$index]['docBlock'] = $this->lrdDocComment($reflectionMethod->getDocComment());
-
                 $controllersInfo[$index]['rules'] = array_merge(
                     $controllersInfo[$index]['rules'] ?? [],
                     $customRules,
                 );
             }
+            
+            $controllersInfo[$index]['docBlock'] = $this->lrdDocComment($reflectionMethod->getDocComment());
+
         }
         return $controllersInfo;
     }


### PR DESCRIPTION
I have a problem that methods without params documents not shown, and now fixed