### PR TITLE
Remove unwanted tr after search result

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -133,9 +133,9 @@
             <table class="table-fixed text-sm mt-5" style="width: max-content">
                 <tbody>
                     @foreach ($docs as $index => $doc)
-                    <tr>
+                    <tr v-if="!docs[{{$index}}]['isHidden']">
                         <td>
-                            <a href="#{{$doc['methods'][0] .'-'. $doc['uri']}}" @click="highlightSidebar({{$index}})" v-if="!docs[{{$index}}]['isHidden']">
+                            <a href="#{{$doc['methods'][0] .'-'. $doc['uri']}}" @click="highlightSidebar({{$index}})" >
                                 <span class="
                                     font-medium
                                     inline-flex


### PR DESCRIPTION
Hello, @kevincobain2000 
Remove unwanted tr (It generate extra space) after search result

![image](https://user-images.githubusercontent.com/18529326/191256264-daa4ae0c-a625-4c13-bf3f-b59bcf9d5cae.png)
