### PR TITLE
Fix id navigation and add quality-of-life configuration options

### DIFF
--- a/config/request-docs.php
+++ b/config/request-docs.php
@@ -25,6 +25,11 @@ return [
         'Authorization' => 'Bearer',
     ],
 
+    /*
+    * Show development relevant metadata on endpoints
+    */
+    'show_development_metadata' => true,
+
     /**
      * Path to to static HTML if using command line.
      */

--- a/config/request-docs.php
+++ b/config/request-docs.php
@@ -16,6 +16,15 @@ return [
         // \App\Http\Middleware\NotFoundWhenProduction::class,
     ],
 
+    /*
+    * Default headers shown on the request headers editor
+    */
+    'default_request_headers' => [
+        'Accept' => 'application/json',
+        'X-CSRF-TOKEN' => '',
+        'Authorization' => 'Bearer',
+    ],
+
     /**
      * Path to to static HTML if using command line.
      */

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -212,7 +212,7 @@
                         {{$doc['methods'][0]}}
                     </span>
                     <span class="">
-                        <a href="#{{$doc['uri']}}">{{$doc['uri']}}</a>
+                        <a href="#{{$doc['httpMethod'] .'-'. $doc['uri']}}">{{$doc['uri']}}</a>
                     </span>
                 </h1>
                 </div>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -660,9 +660,7 @@
                 filterTerm: ''
             },
             created: function () {
-                axios.defaults.headers.common['X-CSRF-TOKEN'] = document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
-                axios.defaults.headers.common['Authorization'] = 'Bearer '
-                this.requestHeaders = JSON.stringify(axios.defaults.headers.common, null, 2)
+                this.requestHeaders = JSON.stringify({!! json_encode(config('request-docs.default_request_headers')) !!}, null, 2)
             },
             methods: {
                 highlightSidebar(idx) {

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -216,6 +216,7 @@
                     </span>
                 </h1>
                 </div>
+                @if (!config('request-docs.show_development_metadata'))
                 <table class="table-fixed text-sm mt-5">
                     <tbody>
                         <tr>
@@ -244,6 +245,7 @@
                         @endforeach
                     </tbody>
                 </table>
+                @endif
                 <div v-if="docs[{{$index}}]['docBlock']" class="border-2 mr-4 mt-4 p-4 rounded text-sm">
                     <h3 class="font-bold">Description</h3>
                     <hr>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -216,7 +216,7 @@
                     </span>
                 </h1>
                 </div>
-                @if (!config('request-docs.show_development_metadata'))
+                @if (config('request-docs.show_development_metadata'))
                 <table class="table-fixed text-sm mt-5">
                     <tbody>
                         <tr>


### PR DESCRIPTION
Hello, this PR is divided in 2 sections:

First of all I have fixed the id navigation on the endpoint body, the `href` reference wasn't generating the correct values and links on the URL field weren't working.

Second, I've added two configuration options:

 - The ability to customize default headers. Very useful to speed up testing on different projects.
 - The ability to hide development metadata. Key if the API docs are intended for public use, there's no need of showing folder structure nor class names.

I've kept the previous behaviour as default on the configuration files, but now they are overwritable.