### PR TITLE
fix bug not skipping duplicate routes

### DIFF
--- a/src/LaravelRequestDocs.php
+++ b/src/LaravelRequestDocs.php
@@ -85,7 +85,7 @@ class LaravelRequestDocs
                 foreach ($controllersInfo as $controllerInfo) {
                     if ($controllerInfo['uri'] == $route->uri && $controllerInfo['httpMethod'] == $httpMethod) {
                         // is duplicate
-                        continue;
+                        continue 2;
                     }
                 }
 


### PR DESCRIPTION
`continue;` do not skip the route because we are already in a foreach
`continue 2;` will skip it ! :)