### PR TITLE
Implement group feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 - Support for Authorization Headers
 - Display extra documentation using markdown
 - Saves history previous requests
-- Added filters to sort, group and filter routes by methods, controllers, middlewares, routes (also see Roadmap 2.x)
+- Added filters to sort, group and filter routes by methods, controllers, middlewares, routes
 - Export laravel API, routes, rules and documentation to Postman and OpenAPI 3.0.0
 
 # Read on Medium
@@ -156,9 +156,8 @@ Fixing lints
 
 # Roadmap for v2.x
 
-- [DONE] UI renewal
-- [WIP] Introduce groupby controller names, routes, middlewares
-- [WIP] Introduce fetch rules from PHP doc annotations
+- UI renewal
+- Introduce groupby controller names, routes, middlewares
 
 # Changelog
 
@@ -181,5 +180,7 @@ Fixing lints
 - v2.0 UI Renewal to React static
     - `@QAParam` is now `@LRDparam`
     - No special changes for users, upgrade to v2.x as usual
+    - Upgrading users will need to republish config
 - v2.1 UI - adds search bar and few aligment fixes on table
 - v2.2 PHP 8.1 and 8.2 support added
+- v2.3 Groupby enabled for routes and controllers

--- a/config/request-docs.php
+++ b/config/request-docs.php
@@ -37,6 +37,15 @@ return [
     // Can be overridden as // @LRDResponses 200|400|401
     'default_responses' => [ "200", "400", "401", "403", "404", "405", "422", "429", "500", "503"],
 
+    // By default, LRD group your routes by the first /path.
+    // This is a set of regex to group your routes by prefix.
+    'group_by' => [
+        'uri_patterns' => [
+            '^api/v[\d]+/', // `/api/v1/users/store` group as `/api/v1/users`.
+            '^api/',        // `/api/users/store` group as `/api/users`.
+        ]
+    ],
+
     // No need to touch below
     // open api config
     // used to generate open api json

--- a/src/Controllers/LaravelRequestDocsController.php
+++ b/src/Controllers/LaravelRequestDocsController.php
@@ -60,8 +60,6 @@ class LaravelRequestDocsController extends Controller
             Response::HTTP_OK,
             [
                 'Content-type'=> 'application/json; charset=utf-8',
-                'Cache-Control' => 'public, max-age=60',
-                'Expires' => gmdate('D, d M Y H:i:s \G\M\T', time() + 60),
             ],
             JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
         );

--- a/tests/LRDTest.php
+++ b/tests/LRDTest.php
@@ -3,6 +3,8 @@
 namespace Rakutentech\LaravelRequestDocs\Tests;
 
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Route;
+use Rakutentech\LaravelRequestDocs\Tests\TestControllers\UserController;
 
 class LRDTest extends TestCase
 {
@@ -43,5 +45,285 @@ class LRDTest extends TestCase
         foreach ($docs as $doc) {
             $this->assertStringStartsWith('welcome', $doc['uri']);
         }
+    }
+
+    public function testGroupByURI()
+    {
+        Route::get('users', [UserController::class]);
+        Route::post('users', [UserController::class]);
+        Route::put('users/update', [UserController::class]);
+        Route::put('api/users/', [UserController::class]);
+        Route::put('api/users/{id}', [UserController::class]);
+        Route::put('api/users_roles/{id}', [UserController::class]);
+        Route::put('api/v1/users', [UserController::class]);
+        Route::put('api/v1/users/{id}/store', [UserController::class]);
+        Route::put('api/v2/users', [UserController::class]);
+        Route::put('api/v99/users', [UserController::class]);
+
+        $docs = $this->lrd->getDocs();
+        $docs = $this->lrd->groupDocs($docs, 'api_uri');
+
+        $grouped = collect($docs)
+            ->map(function (array $item) {
+                return collect($item)->only(['uri', 'group', 'group_index', 'httpMethod'])->toArray();
+            })
+            ->groupBy('group');
+
+        $expected = [
+            '' => [
+                [
+                    'uri' => '/',
+                    'httpMethod' => 'GET',
+                    'group' => '',
+                    'group_index' => 0
+                ]
+            ],
+            'welcome' => [
+                [
+                    'uri' => 'welcome',
+                    'httpMethod' => 'GET',
+                    'group' => 'welcome',
+                    'group_index' => 0
+                ],
+                [
+                    'uri' => 'welcome',
+                    'httpMethod' => 'POST',
+                    'group' => 'welcome',
+                    'group_index' => 1
+                ],
+                [
+                    'uri' => 'welcome',
+                    'httpMethod' => 'PUT',
+                    'group' => 'welcome',
+                    'group_index' => 2
+                ],
+                [
+                    'uri' => 'welcome',
+                    'httpMethod' => 'DELETE',
+                    'group' => 'welcome',
+                    'group_index' => 3
+                ]
+            ],
+            'single' => [
+                [
+                    'uri' => 'single',
+                    'httpMethod' => 'GET',
+                    'group' => 'single',
+                    'group_index' => 0
+                ]
+            ],
+            'users' => [
+                [
+                    'uri' => 'users',
+                    'httpMethod' => 'GET',
+                    'group' => 'users',
+                    'group_index' => 0
+                ],
+                [
+                    'uri' => 'users',
+                    'httpMethod' => 'POST',
+                    'group' => 'users',
+                    'group_index' => 1
+                ],
+                [
+                    'uri' => 'users/update',
+                    'httpMethod' => 'PUT',
+                    'group' => 'users',
+                    'group_index' => 2
+                ]
+            ],
+            'api/users' => [
+                [
+                    'uri' => 'api/users',
+                    'httpMethod' => 'PUT',
+                    'group' => 'api/users',
+                    'group_index' => 0
+                ],
+                [
+                    'uri' => 'api/users/{id}',
+                    'httpMethod' => 'PUT',
+                    'group' => 'api/users',
+                    'group_index' => 1
+                ]
+            ],
+            'api/users_roles' => [
+                [
+                    'uri' => 'api/users_roles/{id}',
+                    'httpMethod' => 'PUT',
+                    'group' => 'api/users_roles',
+                    'group_index' => 0
+                ]
+            ],
+            'api/v1/users' => [
+                [
+                    'uri' => 'api/v1/users',
+                    'httpMethod' => 'PUT',
+                    'group' => 'api/v1/users',
+                    'group_index' => 0
+                ],
+                [
+                    'uri' => 'api/v1/users/{id}/store',
+                    'httpMethod' => 'PUT',
+                    'group' => 'api/v1/users',
+                    'group_index' => 1
+                ]
+            ],
+            'api/v2/users' => [
+                [
+                    'uri' => 'api/v2/users',
+                    'httpMethod' => 'PUT',
+                    'group' => 'api/v2/users',
+                    'group_index' => 0
+                ]
+            ],
+            'api/v99/users' => [
+                [
+                    'uri' => 'api/v99/users',
+                    'httpMethod' => 'PUT',
+                    'group' => 'api/v99/users',
+                    'group_index' => 0
+                ]
+            ]
+        ];
+        $this->assertSame($expected, $grouped->toArray());
+    }
+
+    public function testGroupByURIBackwardCompatible()
+    {
+        // Set to `null` to test backward compatibility.
+        Config::set('request-docs.group_by.uri_patterns', []);
+
+        $docs = $this->lrd->getDocs();
+        $docs = $this->lrd->groupDocs($docs, 'api_uri');
+        $grouped = collect($docs)
+            ->map(function (array $item) {
+                return collect($item)->only(['uri', 'group', 'group_index', 'httpMethod'])->toArray();
+            })
+            ->groupBy('group');
+
+        $expected = [
+            "" => [
+                [
+                    "uri" => "/",
+                    "httpMethod" => "GET",
+                    "group" => "",
+                    "group_index" => 0
+                ]
+            ],
+            "welcome" => [
+                [
+                    "uri" => "welcome",
+                    "httpMethod" => "GET",
+                    "group" => "welcome",
+                    "group_index" => 0
+                ],
+                [
+                    "uri" => "welcome",
+                    "httpMethod" => "POST",
+                    "group" => "welcome",
+                    "group_index" => 1
+                ],
+                [
+                    "uri" => "welcome",
+                    "httpMethod" => "PUT",
+                    "group" => "welcome",
+                    "group_index" => 2
+                ],
+                [
+                    "uri" => "welcome",
+                    "httpMethod" => "DELETE",
+                    "group" => "welcome",
+                    "group_index" => 3
+                ]
+            ],
+            "single" => [
+                [
+                    "uri" => "single",
+                    "httpMethod" => "GET",
+                    "group" => "single",
+                    "group_index" => 0
+                ]
+            ]
+        ];
+        $this->assertSame($expected, $grouped->toArray());
+    }
+
+    public function testGroupByFQController()
+    {
+        Route::get('users', [UserController::class]);
+        Route::post('users', [UserController::class]);
+        Route::put('users/update', [UserController::class]);
+        $docs = $this->lrd->getDocs();
+        $docs = $this->lrd->groupDocs($docs, 'controller_full_path');
+
+        $grouped = collect($docs)
+            ->map(function (array $item) {
+                return collect($item)->only(['controller_full_path', 'group', 'group_index', 'httpMethod'])->toArray();
+            })
+            ->groupBy('group');
+
+        $expected = [
+            'Rakutentech\LaravelRequestDocs\Tests\TestControllers\WelcomeController' => [
+                [
+                    'controller_full_path' => 'Rakutentech\LaravelRequestDocs\Tests\TestControllers\WelcomeController',
+                    'httpMethod' => 'GET',
+                    'group' => 'Rakutentech\LaravelRequestDocs\Tests\TestControllers\WelcomeController',
+                    'group_index' => 0
+                ],
+                [
+                    'controller_full_path' => 'Rakutentech\LaravelRequestDocs\Tests\TestControllers\WelcomeController',
+                    'httpMethod' => 'GET',
+                    'group' => 'Rakutentech\LaravelRequestDocs\Tests\TestControllers\WelcomeController',
+                    'group_index' => 1
+                ],
+                [
+                    'controller_full_path' => 'Rakutentech\LaravelRequestDocs\Tests\TestControllers\WelcomeController',
+                    'httpMethod' => 'POST',
+                    'group' => 'Rakutentech\LaravelRequestDocs\Tests\TestControllers\WelcomeController',
+                    'group_index' => 2
+                ],
+                [
+                    'controller_full_path' => 'Rakutentech\LaravelRequestDocs\Tests\TestControllers\WelcomeController',
+                    'httpMethod' => 'PUT',
+                    'group' => 'Rakutentech\LaravelRequestDocs\Tests\TestControllers\WelcomeController',
+                    'group_index' => 3
+                ],
+                [
+                    'controller_full_path' => 'Rakutentech\LaravelRequestDocs\Tests\TestControllers\WelcomeController',
+                    'httpMethod' => 'DELETE',
+                    'group' => 'Rakutentech\LaravelRequestDocs\Tests\TestControllers\WelcomeController',
+                    'group_index' => 4
+                ]
+            ],
+            'Rakutentech\LaravelRequestDocs\Tests\TestControllers\SingleActionController' => [
+                [
+                    'controller_full_path' => 'Rakutentech\LaravelRequestDocs\Tests\TestControllers\SingleActionController',
+                    'httpMethod' => 'GET',
+                    'group' => 'Rakutentech\LaravelRequestDocs\Tests\TestControllers\SingleActionController',
+                    'group_index' => 0
+                ]
+            ],
+            'Rakutentech\LaravelRequestDocs\Tests\TestControllers\UserController' => [
+                [
+                    'controller_full_path' => 'Rakutentech\LaravelRequestDocs\Tests\TestControllers\UserController',
+                    'httpMethod' => 'GET',
+                    'group' => 'Rakutentech\LaravelRequestDocs\Tests\TestControllers\UserController',
+                    'group_index' => 0
+                ],
+                [
+                    'controller_full_path' => 'Rakutentech\LaravelRequestDocs\Tests\TestControllers\UserController',
+                    'httpMethod' => 'POST',
+                    'group' => 'Rakutentech\LaravelRequestDocs\Tests\TestControllers\UserController',
+                    'group_index' => 1
+                ],
+                [
+                    'controller_full_path' => 'Rakutentech\LaravelRequestDocs\Tests\TestControllers\UserController',
+                    'httpMethod' => 'PUT',
+                    'group' => 'Rakutentech\LaravelRequestDocs\Tests\TestControllers\UserController',
+                    'group_index' => 2
+                ]
+            ]
+        ];
+        $this->assertSame($expected, $grouped->toArray());
     }
 }

--- a/tests/TestControllers/UserController.php
+++ b/tests/TestControllers/UserController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rakutentech\LaravelRequestDocs\Tests\TestControllers;
+
+use Illuminate\Http\Response;
+
+class UserController
+{
+    public function __invoke(): Response
+    {
+        return response(true);
+    }
+}

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -16,6 +16,8 @@ interface IAPIInfo {
     httpMethod: string;
     rules: IAPIRule;
     docBlock: string;
+    group: string|null;
+    group_index: number|null;
 }
 
 interface Props {
@@ -33,17 +35,25 @@ export default function Sidebar(props: Props) {
                 </h2>
                 <ul>
                     {lrdDocsJson.map((lrdDocsItem) => (
-                        lrdDocsItem.methods.map((method) => (
-                            <li key={shortid.generate()}>
-                                <AnchorLink href={'#' + method + lrdDocsItem.uri} className="flex flex-row px-0 py-1">
-                                    <span className={`method-${method} uppercase text-xs w-12 p-0 flex flex-row-reverse`}>
-                                        {method}
-                                    </span>
-                                    <span className="flex-1 p-0 text-sm text-left break-all">
-                                        {lrdDocsItem.uri}
-                                    </span>
-                                </AnchorLink>
-                            </li>
+                        lrdDocsItem.methods.map((method, methodIndex) => (
+                            <div key={shortid.generate()}>
+                                {(lrdDocsItem.group != null && lrdDocsItem.group != "" && lrdDocsItem.group_index == 0 && methodIndex == 0) && (
+                                    <li className="pt-5 text-slate-600">
+                                        {/* Only in case of controller names full path -> just controller name */}
+                                        {lrdDocsItem.group.split('\\').pop()}
+                                    </li>
+                                )}
+                                <li>
+                                    <AnchorLink href={'#' + method + lrdDocsItem.uri} className="flex flex-row px-0 py-1">
+                                        <span className={`method-${method} uppercase text-xs w-12 p-0 flex flex-row-reverse`}>
+                                            {method}
+                                        </span>
+                                        <span className="flex-1 p-0 text-sm text-left break-all">
+                                            {lrdDocsItem.uri}
+                                        </span>
+                                    </AnchorLink>
+                                </li>
+                            </div>
                         ))
                     ))}
                     <li className='bg-transparent'></li>

--- a/ui/src/components/TopNav.tsx
+++ b/ui/src/components/TopNav.tsx
@@ -130,21 +130,20 @@ export default function TopNav(props: Props) {
                                         <span className="label-text">HTTP Methods</span>
                                     </label>
                                 </div>
-                                {/* Not Implemented */}
-                                {/* <h4 className="font-bold mt-10">Group By</h4>
+                                <h4 className="font-bold mt-10">Group By</h4>
                                 <div className="form-control">
                                     <label className="label">
                                         
                                         <input type="radio" onChange={handleChangeGroupby} value="default" className="radio" checked={groupby == "default"} />
                                         <span className="label-text">Default</span>
                                         
-                                        <input type="radio" onChange={handleChangeGroupby} value="controller_names" className="radio" checked={groupby == "controller_names"} />
-                                        <span className="label-text">Controllers</span>
+                                        <input type="radio" onChange={handleChangeGroupby} value="api_uri" className="radio" checked={groupby == "api_uri"} />
+                                        <span className="label-text">API URI</span>
                                         
-                                        <input type="radio" onChange={handleChangeGroupby} value="middleware_names" className="radio" checked={groupby == "middleware_names"} />
-                                        <span className="label-text">Middlewares</span>
+                                        <input type="radio" onChange={handleChangeGroupby} value="controller_full_path" className="radio" checked={groupby == "controller_full_path"} />
+                                        <span className="label-text">Controller Names</span>
                                     </label>
-                                </div> */}
+                                </div>
                                 <h4 className="font-bold mt-10">Display Settings</h4>
                                 <div className="form-control">
                                     <label className="label">


### PR DESCRIPTION
Close #121 

## Group options:

1. `api_uri`
2. `controller_full_path`

Check test `testGroupByURI` and `testGroupByFQController` for the group result.

## Config changes

Added `request-docs.group_by.uri_patterns` to group uri by the prefix.

