### PR TITLE
194 fixed header

### DIFF
--- a/ui/src/components/App.tsx
+++ b/ui/src/components/App.tsx
@@ -126,18 +126,20 @@ export default function App() {
     }
     return (
         <>
-            <TopNav handleChangeSettings={handleChangeSettings} handleSearch={handleSearch} />
-            {sendingRequest && (
-                <progress className="progress progress-success w-full"></progress>
-            )}
-            {!sendingRequest && (
-                <progress className="progress w-full" value="100"></progress>
-            )}
-            {error && (
-                <div className="alert alert-error rounded-none">
-                    {error}
-                </div>
-            )}
+            <div className="sticky top-0 z-50 bg-gray-400">
+                <TopNav handleChangeSettings={handleChangeSettings} handleSearch={handleSearch} />
+                {sendingRequest && (
+                    <progress className="progress progress-success w-full"></progress>
+                )}
+                {!sendingRequest && (
+                    <progress className="progress w-full" value="100"></progress>
+                )}
+                {error && (
+                    <div className="alert alert-error rounded-none">
+                        {error}
+                    </div>
+                )}
+            </div>
             <div className="main-grid grid grid-cols-10 gap-2">
                 <div className="sidebar-wrapper col-span-3">
                     <div className='min-h-screen'>
@@ -150,10 +152,10 @@ export default function App() {
                             <div className="min-h-screen">
                                 <div className="main-grid grid grid-cols-10 gap-2">
                                     <div className="col-span-4 ml-5">
-                                        <ApiInfo lrdDocsItem={lrdDocsItem} method={lrdDocsItem.http_method}/>
+                                        <ApiInfo lrdDocsItem={lrdDocsItem} method={lrdDocsItem.http_method} />
                                     </div>
                                     <div className="col-span-5 ml-5">
-                                        <ApiAction lrdDocsItem={lrdDocsItem} method={lrdDocsItem.http_method} host={host}/>
+                                        <ApiAction lrdDocsItem={lrdDocsItem} method={lrdDocsItem.http_method} host={host} />
                                     </div>
                                 </div>
                             </div>

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -31,6 +31,7 @@ export default function Sidebar(props: Props) {
                                 <AnchorLink href={'#' + lrdDocsItem.http_method + lrdDocsItem.uri}
                                     onClick={() => {
                                         window.history.pushState({}, '', '#' + lrdDocsItem.http_method + lrdDocsItem.uri);
+                                        setTimeout(() => {window.scrollBy(0, -128)}, 600); 
                                     }}
                                     className="flex flex-row px-0 py-1">
                                         <span className={`method-${lrdDocsItem.http_method} uppercase text-xs w-12 p-0 flex flex-row-reverse`}>

--- a/ui/src/global.css
+++ b/ui/src/global.css
@@ -46,6 +46,10 @@ td {
     overflow: scroll;
 }
 
+h2[id] {
+    scroll-margin: 8rem;
+}
+
 .table th.param-cell {
     @apply font-normal;
     @apply truncate;


### PR DESCRIPTION
close #194 

To address the disappearance of the nav-bar on scrolling I have:
- Wrapped the NavBar, progress bar and error message in a div and applied the suggested tailwindCSS to keep it in place on scrolling.
- Applied global CSS to `h2` tags with an `id` attribute to have `scroll-margin-top: 8rem;` so that if a link to a particular section is shared, the page opens with the heading **not** hidden behind the nav bar.
- Added a `setTimeout()` with a delay of 600ms and callback triggering `window.scrollBy(0, -128)` to the `onClick` function of the sidebar menu links.

The reason for the additional JS was that I tried multiple ways to make sure the `scroll-margin-top` applied when clicking the fragment links in the sidebar menu, but it just would not work. I opted to use a delayed window manipulation as the page needs time to scroll to the desired place before making the "adjustment" scroll.

I understand this approach is a little strange, and think that it may be a problem if the number of links exceeds 100 and the time needed to scroll from top to bottom may be longer than the chosen 600ms. If you like, I could create a function to calculate a sufficient delay based on the length of the JSON of data. Just thought it best to ask if that is even required first.