### PR TITLE
Update LaravelRequestDocsServiceProvider.php

### DIFF
--- a/src/LaravelRequestDocsServiceProvider.php
+++ b/src/LaravelRequestDocsServiceProvider.php
@@ -24,6 +24,7 @@ class LaravelRequestDocsServiceProvider extends PackageServiceProvider
         // publish resources/dist/_astro to public/
         $this->publishes([
             __DIR__.'/../resources/dist/_astro' => public_path('request-docs/_astro'),
+            __DIR__.'/../resources/dist/index.html' => public_path('request-docs/index.html'),
         ], 'request-docs-assets');
     }
 


### PR DESCRIPTION
Copy index.html to public/request-docs when run the “php artisan vendor:publish --tag=request-docs-assets” command

This file is also necessary for correct nginx routing, because if the request-docs folder is present, nginx tries to detect the index file and returns 404 on error