### PR TITLE
Open API 3 Path Parameter & Delete Standard Rule Check Failed Issue Fixed  

### DIFF
--- a/config/request-docs.php
+++ b/config/request-docs.php
@@ -71,6 +71,8 @@ return [
         //openapi 3.0.x doesn't support request body for develop operation
         //ref: https://github.com/OAI/OpenAPI-Specification/pull/2117
         'include_body_on_delete' => false,
+        //exclude http methods that will be excluded from openapi export
+        'exclude_http_methods' => [],
         // for now putting default responses for all. This can be changed later based on specific needs
         'responses' => [
             '200' => [

--- a/config/request-docs.php
+++ b/config/request-docs.php
@@ -68,7 +68,9 @@ return [
         'license' => 'Apache 2.0',
         'license_url' => 'https://www.apache.org/licenses/LICENSE-2.0.html',
         'server_url' => env('APP_URL', 'http://localhost'),
-
+        //openapi 3.0.x doesn't support request body for develop operation
+        //ref: https://github.com/OAI/OpenAPI-Specification/pull/2117
+        'include_body_on_delete' => false,
         // for now putting default responses for all. This can be changed later based on specific needs
         'responses' => [
             '200' => [

--- a/config/request-docs.php
+++ b/config/request-docs.php
@@ -58,7 +58,11 @@ return [
         'description' => 'Laravel Request Docs',
         // default version that this library provides
         'version' => '3.0.0',
-        // changeable
+        // api document title
+        'document_title' => 'Laravel Request',
+        // api document description
+        'document_description' => 'Laravel Request',
+        //api document version
         'document_version' => '1.0.0',
         // license that you want to display
         'license' => 'Apache 2.0',

--- a/config/request-docs.php
+++ b/config/request-docs.php
@@ -58,11 +58,7 @@ return [
         'description' => 'Laravel Request Docs',
         // default version that this library provides
         'version' => '3.0.0',
-        // api document title
-        'document_title' => 'Laravel Request',
-        // api document description
-        'document_description' => 'Laravel Request',
-        //api document version
+        //changeable
         'document_version' => '1.0.0',
         // license that you want to display
         'license' => 'Apache 2.0',

--- a/config/request-docs.php
+++ b/config/request-docs.php
@@ -58,15 +58,15 @@ return [
         'description' => 'Laravel Request Docs',
         // default version that this library provides
         'version' => '3.0.0',
-        //changeable
+        // changeable
         'document_version' => '1.0.0',
         // license that you want to display
         'license' => 'Apache 2.0',
         'license_url' => 'https://www.apache.org/licenses/LICENSE-2.0.html',
         'server_url' => env('APP_URL', 'http://localhost'),
-        //openapi 3.0.x doesn't support request body for develop operation
+        //openapi 3.0.x doesn't support request body for delete operation
         //ref: https://github.com/OAI/OpenAPI-Specification/pull/2117
-        'include_body_on_delete' => false,
+        'delete_with_body' => false,
         //exclude http methods that will be excluded from openapi export
         'exclude_http_methods' => [],
         // for now putting default responses for all. This can be changed later based on specific needs

--- a/src/LaravelRequestDocs.php
+++ b/src/LaravelRequestDocs.php
@@ -47,7 +47,7 @@ class LaravelRequestDocs
             Request::METHOD_PATCH  => $showPatch,
             Request::METHOD_DELETE => $showDelete,
             Request::METHOD_HEAD   => $showHead,
-        ], fn(bool $shouldShow) => $shouldShow);
+        ], fn (bool $shouldShow) => $shouldShow);
 
         /** @var string[] $methods */
         $methods = array_keys($filteredMethods);
@@ -402,7 +402,7 @@ class LaravelRequestDocs
             $comments = $this->multiExplode([' ', '|'], $comment);
 
             if (count($comments) > 0) {
-                $params[$comments[0]] = array_values(array_filter($comments, fn($item) => $item !== $comments[0]));
+                $params[$comments[0]] = array_values(array_filter($comments, fn ($item) => $item !== $comments[0]));
             }
         }
 

--- a/src/LaravelRequestDocsServiceProvider.php
+++ b/src/LaravelRequestDocsServiceProvider.php
@@ -20,7 +20,7 @@ class LaravelRequestDocsServiceProvider extends PackageServiceProvider
             ->hasConfigFile('request-docs')
             // ->hasAssets()
             ->hasViews();
-            // ->hasAssets();
+        // ->hasAssets();
         // publish resources/dist/_astro to public/
         $this->publishes([
             __DIR__.'/../resources/dist/_astro' => public_path('request-docs/_astro'),

--- a/src/LaravelRequestDocsToOpenApi.php
+++ b/src/LaravelRequestDocsToOpenApi.php
@@ -33,7 +33,7 @@ class LaravelRequestDocsToOpenApi
     private function docsToOpenApi(array $docs): void
     {
         $this->openApi['paths'] = [];
-//        dd($docs);
+        $includeBodyForDelete = config('request-docs.open_api.include_body_on_delete');
         foreach ($docs as $doc) {
             $requestHasFile  = false;
             $httpMethod      = strtolower($doc->getHttpMethod());
@@ -66,7 +66,7 @@ class LaravelRequestDocsToOpenApi
 
             $contentType = $requestHasFile ? 'multipart/form-data' : 'application/json';
 
-            if ($isPost || $isPut || $isDelete) {
+            if ($isPost || $isPut || ($isDelete && $includeBodyForDelete)) {
                 $this->openApi['paths'][$uriLeadingSlash][$httpMethod]['requestBody'] = $this->makeRequestBodyItem($contentType);
             }
 
@@ -76,7 +76,7 @@ class LaravelRequestDocsToOpenApi
                         $parameter                                                             = $this->makeQueryParameterItem($attribute, $rule);
                         $this->openApi['paths'][$uriLeadingSlash][$httpMethod]['parameters'][] = $parameter;
                     }
-                    if ($isPost || $isPut || $isDelete) {
+                    if ($isPost || $isPut || ($isDelete && $includeBodyForDelete)) {
                         $this->openApi['paths'][$uriLeadingSlash][$httpMethod]['requestBody']['content'][$contentType]['schema']['properties'][$attribute] = $this->makeRequestBodyContentPropertyItem($rule);
                     }
                 }

--- a/src/LaravelRequestDocsToOpenApi.php
+++ b/src/LaravelRequestDocsToOpenApi.php
@@ -33,7 +33,7 @@ class LaravelRequestDocsToOpenApi
     private function docsToOpenApi(array $docs): void
     {
         $this->openApi['paths'] = [];
-        $includeBodyForDelete   = config('request-docs.open_api.include_body_on_delete', false);
+        $deleteWithBody   = config('request-docs.open_api.delete_with_body', false);
         $excludeHttpMethods     = array_map(fn ($item) => strtolower($item), config('request-docs.open_api.exclude_http_methods', []));
 
         foreach ($docs as $doc) {
@@ -74,7 +74,7 @@ class LaravelRequestDocsToOpenApi
 
             $contentType = $requestHasFile ? 'multipart/form-data' : 'application/json';
 
-            if ($isPost || $isPut || ($isDelete && $includeBodyForDelete)) {
+            if ($isPost || $isPut || ($isDelete && $deleteWithBody)) {
                 $this->openApi['paths'][$uriLeadingSlash][$httpMethod]['requestBody'] = $this->makeRequestBodyItem($contentType);
             }
 
@@ -84,7 +84,7 @@ class LaravelRequestDocsToOpenApi
                         $parameter                                                             = $this->makeQueryParameterItem($attribute, $rule);
                         $this->openApi['paths'][$uriLeadingSlash][$httpMethod]['parameters'][] = $parameter;
                     }
-                    if ($isPost || $isPut || ($isDelete && $includeBodyForDelete)) {
+                    if ($isPost || $isPut || ($isDelete && $deleteWithBody)) {
                         $this->openApi['paths'][$uriLeadingSlash][$httpMethod]['requestBody']['content'][$contentType]['schema']['properties'][$attribute] = $this->makeRequestBodyContentPropertyItem($rule);
                     }
                 }
@@ -102,7 +102,6 @@ class LaravelRequestDocsToOpenApi
         if (is_array($rule)) {
             $rule = implode('|', $rule);
         }
-
         $parameter = [
             'name'        => $attribute,
             'description' => $rule,

--- a/src/LaravelRequestDocsToOpenApi.php
+++ b/src/LaravelRequestDocsToOpenApi.php
@@ -94,6 +94,7 @@ class LaravelRequestDocsToOpenApi
         if (is_array($rule)) {
             $rule = implode('|', $rule);
         }
+
         $parameter = [
             'name'        => $attribute,
             'description' => $rule,
@@ -112,11 +113,12 @@ class LaravelRequestDocsToOpenApi
         if (is_array($rule)) {
             $rule = implode('|', $rule);
         }
+
         $parameter = [
             'name'        => $attribute,
             'description' => $rule,
-            'in'          => 'query',
-            'style'       => 'form',
+            'in'          => 'path',
+            'style'       => 'simple',
             'required'    => str_contains($rule, 'required'),
             'schema'      => [
                 'type' => $this->getAttributeType($rule),

--- a/src/LaravelRequestDocsToOpenApi.php
+++ b/src/LaravelRequestDocsToOpenApi.php
@@ -33,6 +33,7 @@ class LaravelRequestDocsToOpenApi
     private function docsToOpenApi(array $docs): void
     {
         $this->openApi['paths'] = [];
+//        dd($docs);
         foreach ($docs as $doc) {
             $requestHasFile  = false;
             $httpMethod      = strtolower($doc->getHttpMethod());
@@ -46,7 +47,7 @@ class LaravelRequestDocsToOpenApi
             $this->openApi['paths'][$uriLeadingSlash][$httpMethod]['parameters']  = [];
 
             foreach ($doc->getPathParameters() as $parameter => $rule) {
-                $this->openApi['paths'][$uriLeadingSlash][$httpMethod]['parameters'][] = $this->makeQueryParameterItem($parameter, $rule);
+                $this->openApi['paths'][$uriLeadingSlash][$httpMethod]['parameters'][] = $this->makePathParameterItem($parameter, $rule);
             }
 
             $this->openApi['paths'][$uriLeadingSlash][$httpMethod]['responses'] = config('request-docs.open_api.responses', []);
@@ -89,6 +90,24 @@ class LaravelRequestDocsToOpenApi
     }
 
     protected function makeQueryParameterItem(string $attribute, $rule): array
+    {
+        if (is_array($rule)) {
+            $rule = implode('|', $rule);
+        }
+        $parameter = [
+            'name'        => $attribute,
+            'description' => $rule,
+            'in'          => 'query',
+            'style'       => 'form',
+            'required'    => str_contains($rule, 'required'),
+            'schema'      => [
+                'type' => $this->getAttributeType($rule),
+            ],
+        ];
+        return $parameter;
+    }
+
+    protected function makePathParameterItem(string $attribute, $rule): array
     {
         if (is_array($rule)) {
             $rule = implode('|', $rule);

--- a/src/LaravelRequestDocsToOpenApi.php
+++ b/src/LaravelRequestDocsToOpenApi.php
@@ -33,10 +33,18 @@ class LaravelRequestDocsToOpenApi
     private function docsToOpenApi(array $docs): void
     {
         $this->openApi['paths'] = [];
-        $includeBodyForDelete = config('request-docs.open_api.include_body_on_delete');
+        $includeBodyForDelete   = config('request-docs.open_api.include_body_on_delete', false);
+        $excludeHttpMethods     = array_map(fn ($item) => strtolower($item), config('request-docs.open_api.exclude_http_methods', []));
+
         foreach ($docs as $doc) {
-            $requestHasFile  = false;
+
             $httpMethod      = strtolower($doc->getHttpMethod());
+
+            if (in_array($httpMethod, $excludeHttpMethods)) {
+                continue;
+            }
+
+            $requestHasFile  = false;
             $isGet           = $httpMethod == 'get';
             $isPost          = $httpMethod == 'post';
             $isPut           = $httpMethod == 'put';


### PR DESCRIPTION
Changes this PR has these changes for [BUG] #266 
1. **When exporting an OpenAPI3 JSON the Path Parameter values are also generated as query values**
2. **Excluding request body while generating the delete request. As OpenAPI3 discourages request body**
3. **Description Content added from configuration file**
4. **Exclude certain HTTP methods from exporting into JSON. Ex: `HEAD`**