### PR TITLE
Artisan command to export collection as JSON file

### DIFF
--- a/config/request-docs.php
+++ b/config/request-docs.php
@@ -153,4 +153,8 @@ return [
             ],
         ],
     ],
+
+    //export request docs as json file from terminal
+    //from project root directory
+    'export_path' => 'api.json'
 ];

--- a/src/Commands/ExportRequestDocsCommand.php
+++ b/src/Commands/ExportRequestDocsCommand.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Rakutentech\LaravelRequestDocs\Commands;
+
+use Illuminate\Console\Command;
+use Rakutentech\LaravelRequestDocs\LaravelRequestDocs;
+use Rakutentech\LaravelRequestDocs\LaravelRequestDocsToOpenApi;
+
+class ExportRequestDocsCommand extends Command
+{
+    private LaravelRequestDocs          $laravelRequestDocs;
+    private LaravelRequestDocsToOpenApi $laravelRequestDocsToOpenApi;
+
+    public function __construct(LaravelRequestDocs $laravelRequestDoc, LaravelRequestDocsToOpenApi $laravelRequestDocsToOpenApi)
+    {
+        parent::__construct();
+
+        $this->laravelRequestDocs          = $laravelRequestDoc;
+        $this->laravelRequestDocsToOpenApi = $laravelRequestDocsToOpenApi;
+    }
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'laravel-request-docs:export
+                            {path? : Export file location}
+                            {--force : Whether to overwrite existing file}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate OpenAPI collection as json file';
+
+    private string $exportFilePath;
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        if ($this->confirmFilePath()) {
+            try {
+                $excludedMethods = config('request-docs.open_api.exclude_http_methods', []);
+
+                $excludedMethods = array_map(fn($item) => strtolower($item), $excludedMethods);
+
+                $showGet    = !in_array('get', $excludedMethods);
+                $showPost   = !in_array('post', $excludedMethods);
+                $showPut    = !in_array('put', $excludedMethods);
+                $showPatch  = !in_array('patch', $excludedMethods);
+                $showDelete = !in_array('delete', $excludedMethods);
+                $showHead   = !in_array('head', $excludedMethods);
+
+                // Get a list of Doc with route and rules information.
+                // If user defined `Route::match(['get', 'post'], 'uri', ...)`,
+                // only a single Doc will be generated.
+                $docs = $this->laravelRequestDocs->getDocs(
+                    $showGet,
+                    $showPost,
+                    $showPut,
+                    $showPatch,
+                    $showDelete,
+                    $showHead,
+                );
+
+                // Loop and split Doc by the `methods` property.
+                // `Route::match([...n], 'uri', ...)` will generate n number of Doc.
+                $docs = $this->laravelRequestDocs->splitByMethods($docs);
+                $docs = $this->laravelRequestDocs->sortDocs($docs, 'default');
+                $docs = $this->laravelRequestDocs->groupDocs($docs, 'default');
+
+                $content = json_encode(
+                    $this->laravelRequestDocsToOpenApi->openApi($docs->all())->toArray(),
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+                );
+
+                if (!$this->writeFile($content)) {
+                    throw new \ErrorException("Failed to write on [{$this->exportFilePath}] file.");
+                }
+            } catch (\Exception $exception) {
+                $this->error('Error : ' . $exception->getMessage());
+                return self::FAILURE;
+            }
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return bool
+     */
+    private function confirmFilePath(): bool
+    {
+        $path = $this->argument('path');
+
+        if (!$path) {
+            $path = config('request-docs.export_path', 'api.json');
+        }
+
+        $this->exportFilePath = base_path($path);
+
+        $path = str_replace(base_path('/'), '', $this->exportFilePath);
+
+        if (file_exists($this->exportFilePath)) {
+            if (!$this->option('force')) {
+                if ($this->confirm("File exists on [{$path}]. Overwrite?", false) == true) {
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param $content
+     * @return false|int
+     */
+    private function writeFile($content)
+    {
+        $targetDirectory = dirname($this->exportFilePath);
+
+        if (!is_dir($targetDirectory)) {
+            mkdir($targetDirectory, 0755, true);
+        }
+
+        return file_put_contents($this->exportFilePath, $content);
+    }
+}

--- a/src/LaravelRequestDocsServiceProvider.php
+++ b/src/LaravelRequestDocsServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Rakutentech\LaravelRequestDocs;
 
 use Illuminate\Support\Facades\Route;
+use Rakutentech\LaravelRequestDocs\Commands\ExportRequestDocsCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -18,6 +19,7 @@ class LaravelRequestDocsServiceProvider extends PackageServiceProvider
         $package
             ->name('laravel-request-docs')
             ->hasConfigFile('request-docs')
+            ->hasCommand(ExportRequestDocsCommand::class)
             // ->hasAssets()
             ->hasViews();
         // ->hasAssets();


### PR DESCRIPTION
The PR will add an artisan command to export the same open API collection as an exportable JSON file.
using this feature people can generate API docs on the `GIt Action` or `CI/CD` workflow environment.

The artisan command will be `php artisan laravel-request-docs:export`