### PR TITLE
Fix facade accessor

### DIFF
--- a/src/LaravelRequestDocsFacade.php
+++ b/src/LaravelRequestDocsFacade.php
@@ -12,6 +12,6 @@ class LaravelRequestDocsFacade extends Facade
 {
     protected static function getFacadeAccessor()
     {
-        return 'laravel-request-docs';
+        return LaravelRequestDocs::class;
     }
 }


### PR DESCRIPTION
**Problem**
Psalm inspection reports exception on projects that has `laravel-request-doc` as dependency

**To Reproduce**
Steps to reproduce the behavior:
1. `composer create-project laravel/laravel:^10.0 laravel`
2. `cd laravel-request-docs-test`
3. `composer require rakutentech/laravel-request-docs`
4. `composer require --dev vimeo/psalm -W`
5. `composer require --dev psalm/plugin-laravel -W`
6. Add a `psalm.xml` config file with following content:
```xml
<?xml version="1.0"?>
<psalm
    findUnusedCode="true"
    findUnusedBaselineEntry="true"
>
    <projectFiles>
        <directory name="src" />
    </projectFiles>
</psalm>
```
7. `./vendor/bin/psalm-plugin enable psalm/plugin-laravel`
8. `./vendor/bin/psalm`
9. See in the output:
```
Exception: Target class [laravel-request-docs] does not exist.
Skipping \Rakutentech\LaravelRequestDocs\LaravelRequestDocsFacade.
```

**Expected behavior**
Not to see this error.

**Versions:**
- Laravel Version: 10.43
- PHP Version: 8.3.1
- Laravel Request Docs Version: 2.29
