### PR TITLE
Security Section Added

### DIFF
--- a/config/request-docs.php
+++ b/config/request-docs.php
@@ -161,6 +161,16 @@ return [
                 ],
             ],
         ],
+        //openapi export with security configuration,
+        // if type set null then doc will exclude global security schema.
+        // Ref: https://spec.openapis.org/oas/v3.0.3#security-scheme-object
+        'security' => [
+            //available options [null, bearer, basic, apikey]
+            'type' => 'bearer',
+            //Note: only works for "apikey", available options [query, header, cookie]
+            'position' => 'header',
+            'key_name' => 'api_key'
+        ],
     ],
 
     //export request docs as json file from terminal

--- a/config/request-docs.php
+++ b/config/request-docs.php
@@ -165,11 +165,11 @@ return [
         // if type set null then doc will exclude global security schema.
         // Ref: https://spec.openapis.org/oas/v3.0.3#security-scheme-object
         'security' => [
-            //available options [null, bearer, basic, apikey]
+            //available options [null, bearer, basic, apikey, jwt]
             'type' => 'bearer',
-            //Note: only works for "apikey", available options [query, header, cookie]
+            'name' => 'api_key',
+            //Note: only works for "apikey" & "jwt", available options [query, header, cookie]
             'position' => 'header',
-            'key_name' => 'api_key'
         ],
     ],
 

--- a/src/LaravelRequestDocsToOpenApi.php
+++ b/src/LaravelRequestDocsToOpenApi.php
@@ -204,7 +204,8 @@ class LaravelRequestDocsToOpenApi
             case 'bearer':
                 $this->openApi['components']['securitySchemes']['bearerAuth'] = [
                     'type' => 'http',
-                    'name' => config('request-docs.open_api.security.name', 'Bearer Authorization Token'),
+                    'name' => config('request-docs.open_api.security.name', 'Bearer Token'),
+                    'description' => 'Http Bearer Authorization Token',
                     'scheme' => 'bearer'
                 ];
                 $this->openApi['security'][]                                  = [
@@ -215,7 +216,8 @@ class LaravelRequestDocsToOpenApi
             case 'basic':
                 $this->openApi['components']['securitySchemes']['basicAuth'] = [
                     'type' => 'http',
-                    'name' => config('request-docs.open_api.security.name', 'Basic Authorization Username and Password'),
+                    'name' => config('request-docs.open_api.security.name', 'Basic Username and Password'),
+                    'description' => 'Http Basic Authorization Username and Password',
                     'scheme' => 'basic'
                 ];
                 $this->openApi['security'][]                                 = [
@@ -227,7 +229,8 @@ class LaravelRequestDocsToOpenApi
                 $this->openApi['components']['securitySchemes']['apiKeyAuth'] = [
                     'type' => 'apiKey',
                     'name' => config('request-docs.open_api.security.name', 'api_key'),
-                    'in' => config('request-docs.open_api.security.position', 'header')
+                    'in' => config('request-docs.open_api.security.position', 'header'),
+                    'description' => config('app.name').' Provided Authorization Api Key',
                 ];
                 $this->openApi['security'][]                                  = ['apiKeyAuth' => []];
                 break;
@@ -236,8 +239,9 @@ class LaravelRequestDocsToOpenApi
                 $this->openApi['components']['securitySchemes']['bearerAuth'] = [
                     'type' => 'http',
                     'scheme' => 'bearer',
-                    'name' => config('request-docs.open_api.security.name', 'Bearer Authorization Token'),
+                    'name' => config('request-docs.open_api.security.name', 'Bearer JWT Token'),
                     'in' => config('request-docs.open_api.security.position', 'header'),
+                    'description' => 'JSON Web Token',
                     'bearerFormat' => 'JWT'
                 ];
                 $this->openApi['security'][]                                  = [

--- a/src/LaravelRequestDocsToOpenApi.php
+++ b/src/LaravelRequestDocsToOpenApi.php
@@ -23,6 +23,7 @@ class LaravelRequestDocsToOpenApi
         ];
 
         $this->docsToOpenApi($docs);
+        $this->appendGlobalSecurityScheme();
         return $this;
     }
 
@@ -190,6 +191,48 @@ class LaravelRequestDocsToOpenApi
         return "object";
     }
 
+    protected function appendGlobalSecurityScheme(): void
+    {
+        $securityType = config('request-docs.open_api.security.type');
+
+        if ($securityType == null) {
+            return;
+        }
+
+        switch ($securityType) {
+            case 'bearer':
+                $this->openApi['components']['securitySchemes']['bearerAuth'] = [
+                    'type' => 'http',
+                    'scheme' => 'bearer'
+                ];
+                $this->openApi['security'][]                                  = [
+                    'bearerAuth' => []
+                ];
+                break;
+
+            case 'basic':
+                $this->openApi['components']['securitySchemes']['basicAuth'] = [
+                    'type' => 'http',
+                    'scheme' => 'basic'
+                ];
+                $this->openApi['security'][]                                 = [
+                    'basicAuth' => []
+                ];
+                break;
+
+            case 'apikey':
+                $this->openApi['components']['securitySchemes']['apiKeyAuth'] = [
+                    'type' => 'apiKey',
+                    'name' => config('request-docs.open_api.security.key_name', 'api_key'),
+                    'in' => config('request-docs.open_api.security.position', 'header')
+                ];
+                $this->openApi['security'][]                                  = ['apiKeyAuth' => []];
+                break;
+
+            default:
+                break;
+        }
+    }
     /**
      * @codeCoverageIgnore
      */

--- a/src/LaravelRequestDocsToOpenApi.php
+++ b/src/LaravelRequestDocsToOpenApi.php
@@ -7,7 +7,7 @@ class LaravelRequestDocsToOpenApi
     private array $openApi = [];
 
     /**
-     * @param  \Rakutentech\LaravelRequestDocs\Doc[]  $docs
+     * @param \Rakutentech\LaravelRequestDocs\Doc[] $docs
      * @return $this
      */
     public function openApi(array $docs): LaravelRequestDocsToOpenApi
@@ -28,14 +28,14 @@ class LaravelRequestDocsToOpenApi
     }
 
     /**
-     * @param  \Rakutentech\LaravelRequestDocs\Doc[]  $docs
+     * @param \Rakutentech\LaravelRequestDocs\Doc[] $docs
      * @return void
      */
     private function docsToOpenApi(array $docs): void
     {
         $this->openApi['paths'] = [];
         $deleteWithBody         = config('request-docs.open_api.delete_with_body', false);
-        $excludeHttpMethods     = array_map(fn ($item) => strtolower($item), config('request-docs.open_api.exclude_http_methods', []));
+        $excludeHttpMethods     = array_map(fn($item) => strtolower($item), config('request-docs.open_api.exclude_http_methods', []));
 
         foreach ($docs as $doc) {
             $httpMethod = strtolower($doc->getHttpMethod());
@@ -91,6 +91,7 @@ class LaravelRequestDocsToOpenApi
             }
         }
     }
+
     protected function setAndFilterResponses(Doc $doc): array
     {
         $docResponses    = $doc->getResponses();
@@ -116,12 +117,12 @@ class LaravelRequestDocsToOpenApi
             $rule = implode('|', $rule);
         }
         $parameter = [
-            'name'        => $attribute,
+            'name' => $attribute,
             'description' => $rule,
-            'in'          => 'query',
-            'style'       => 'form',
-            'required'    => str_contains($rule, 'required'),
-            'schema'      => [
+            'in' => 'query',
+            'style' => 'form',
+            'required' => str_contains($rule, 'required'),
+            'schema' => [
                 'type' => $this->getAttributeType($rule),
             ],
         ];
@@ -135,12 +136,12 @@ class LaravelRequestDocsToOpenApi
         }
 
         $parameter = [
-            'name'        => $attribute,
+            'name' => $attribute,
             'description' => $rule,
-            'in'          => 'path',
-            'style'       => 'simple',
-            'required'    => str_contains($rule, 'required'),
-            'schema'      => [
+            'in' => 'path',
+            'style' => 'simple',
+            'required' => str_contains($rule, 'required'),
+            'schema' => [
                 'type' => $this->getAttributeType($rule),
             ],
         ];
@@ -151,10 +152,10 @@ class LaravelRequestDocsToOpenApi
     {
         $requestBody = [
             'description' => "Request body",
-            'content'     => [
+            'content' => [
                 $contentType => [
                     'schema' => [
-                        'type'       => 'object',
+                        'type' => 'object',
                         'properties' => [],
                     ],
                 ],
@@ -168,9 +169,9 @@ class LaravelRequestDocsToOpenApi
         $type = $this->getAttributeType($rule);
 
         return [
-            'type'     => $type,
+            'type' => $type,
             'nullable' => str_contains($rule, 'nullable'),
-            'format'   => $this->attributeIsFile($rule) ? 'binary' : $type,
+            'format' => $this->attributeIsFile($rule) ? 'binary' : $type,
         ];
     }
 
@@ -203,6 +204,7 @@ class LaravelRequestDocsToOpenApi
             case 'bearer':
                 $this->openApi['components']['securitySchemes']['bearerAuth'] = [
                     'type' => 'http',
+                    'name' => config('request-docs.open_api.security.name', 'Bearer Authorization Token'),
                     'scheme' => 'bearer'
                 ];
                 $this->openApi['security'][]                                  = [
@@ -213,6 +215,7 @@ class LaravelRequestDocsToOpenApi
             case 'basic':
                 $this->openApi['components']['securitySchemes']['basicAuth'] = [
                     'type' => 'http',
+                    'name' => config('request-docs.open_api.security.name', 'Basic Authorization Username and Password'),
                     'scheme' => 'basic'
                 ];
                 $this->openApi['security'][]                                 = [
@@ -223,16 +226,30 @@ class LaravelRequestDocsToOpenApi
             case 'apikey':
                 $this->openApi['components']['securitySchemes']['apiKeyAuth'] = [
                     'type' => 'apiKey',
-                    'name' => config('request-docs.open_api.security.key_name', 'api_key'),
+                    'name' => config('request-docs.open_api.security.name', 'api_key'),
                     'in' => config('request-docs.open_api.security.position', 'header')
                 ];
                 $this->openApi['security'][]                                  = ['apiKeyAuth' => []];
+                break;
+
+            case 'jwt':
+                $this->openApi['components']['securitySchemes']['bearerAuth'] = [
+                    'type' => 'http',
+                    'scheme' => 'bearer',
+                    'name' => config('request-docs.open_api.security.name', 'Bearer Authorization Token'),
+                    'in' => config('request-docs.open_api.security.position', 'header'),
+                    'bearerFormat' => 'JWT'
+                ];
+                $this->openApi['security'][]                                  = [
+                    'bearerAuth' => []
+                ];
                 break;
 
             default:
                 break;
         }
     }
+
     /**
      * @codeCoverageIgnore
      */


### PR DESCRIPTION
This pull request will add a security scheme the collection is using globally.

1. **Security Type**: [HTTP Basic, HTTP Bearer, API KEY] if the value is set to null then remove the security section.
2. **Name**: if the security type is `apikey` then the name value will be used for query params or Header Key value.
3. **Position**: For security type is `apikey` then position value is used for setting where the API key will be positioned (Header/Query Param)
![image](https://github.com/rakutentech/laravel-request-docs/assets/24684511/f036f36d-c097-4ee4-aa76-89d9e40e1caa)
![image](https://github.com/rakutentech/laravel-request-docs/assets/24684511/c1816ed5-6280-4b2a-adcf-1334f92eca49)
![image](https://github.com/rakutentech/laravel-request-docs/assets/24684511/432a68fb-8718-410a-8ff9-3ad261eee727)
