### PR TITLE
Rules as a Controller Function

### DIFF
--- a/config/request-docs.php
+++ b/config/request-docs.php
@@ -45,7 +45,6 @@ return [
     // Uncomment 'method' to use this feature
     'controller_rules' => [
         //    'method' => 'rules', // method name in controller
-        //    'parameter_for_method_name' => 'method', // parameter name to pass the function name of the controller method
     ],
 
     // Can be overridden as // @LRDresponses 200|400|401

--- a/config/request-docs.php
+++ b/config/request-docs.php
@@ -41,6 +41,13 @@ return [
         'rules'
     ],
 
+    // A method in the controller can be used as source of rules
+    // Uncomment 'method' to use this feature
+    'controller_rules' => [
+        //    'method' => 'rules', // method name in controller
+        //    'parameter_for_method_name' => 'method', // parameter name to pass the function name of the controller method
+    ],
+
     // Can be overridden as // @LRDresponses 200|400|401
     'default_responses' => [ "200", "400", "401", "403", "404", "405", "422", "429", "500", "503"],
 

--- a/src/LaravelRequestDocs.php
+++ b/src/LaravelRequestDocs.php
@@ -236,7 +236,7 @@ class LaravelRequestDocs
             $controllerRulesMethod = config('request-docs.controller_rules.method', null);
 
             // Name of the parameter to pass the method name to the rules function.
-            $controllerRulesMethodParameter = config('request-docs.controller_rules.parameter_for_method_name', 'method');
+            $controllerRulesMethodParameter = 'method';
 
             // Check if the feature is enabled and the controller has the "rules" method.
             if ($controllerRulesMethod && method_exists($doc->getControllerFullPath(), $controllerRulesMethod)) {


### PR DESCRIPTION
In my workflows for relatively simple controllers I like to use a single "rules" function for entire API resource controller. So creating a Request class for each endpoint didn't seem very attractive to me.  

An example (within a Controller class): 
```php
/**
* An example of a simple rules function in a controller
*/
public function rules($method = null, $ref = null)
{
     if ($method != 'store' || $method != 'update') {
         return [];
     }
     
     $rules = [
        'bookable_id' => 'integer',
        'bookable_type' => 'string',
        'starts_at' => 'datetime',
        'ends_at' => 'datetime',
        'price' => 'numeric',
        'currency' => 'string|max:3',
        'notes' => 'nullable|string',
        'method' => 'nullable|' . $method
    ];
    
    if ($method == 'store') {
        $rules['bookable_id'] .= '|required';
    }

    return $rules;
}

public function store(Request $request)
{
    $rules = $this->rules('store');
    // ...
}

public function update(Request $request, Bookable $bookable)
{
    $rules = $this->rules('update', $bookable);
    // ...
}
```

So, I made an extremely simple addition which allows using a `rules()` or `rules($method)` or `rules($etc, $etc=null, $method=null)` function within Controller to be used for getting a rules array. 

Here the `$method` is Controller's function name (index, store, update, myWeirdEndpoint etc...). Both the function name (rules) and function's parameter name ($method) are customizable. 

If config for 'request-docs.controller_rules.method' is not set, feature is completely off. 

I didn't check previous discussions about this, so I don't know if anybody is philosophically against this approach. But I plan to keep this fork in sync with the releases for my own projects. 

_P.S. I didn't get a chance to run unit tests just yet._