### PR TITLE
Drop support for PHP 7.4

### DIFF
--- a/.github/workflows/phptest.yml
+++ b/.github/workflows/phptest.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.4, 8.0, 8.1, 8.2, 8.3]
+        php: [8.0, 8.1, 8.2, 8.3]
         laravel: ['8.*', '11.*']
         include:
           - php: 8.0
@@ -27,8 +27,6 @@ jobs:
           - php: '8.2'
             laravel: 11.*
         exclude:
-          - laravel: 11.*
-            php: 7.4
           - laravel: 11.*
             php: 8.0
           - laravel: 11.*

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0|^8.1|^8.2|^8.3",
+        "php": "^8.0",
         "illuminate/contracts": "^8.37|^9.0|^10.0|^11.0",
         "kitloong/laravel-app-logger": "^1.0",
         "spatie/laravel-package-tools": "^1.4.3",


### PR DESCRIPTION
Updates the repository to drop support for PHP 7.4 and exclusively support PHP versions 8.0 and above.
- **`composer.json` adjustments:**
  - Updates the PHP version requirement to `"php": "^8.0"`, effectively dropping support for PHP 7.4.
- **`.github/workflows/phptest.yml` modifications:**
  - Removes PHP 7.4 from the test matrix, ensuring that automated tests now run only on PHP versions 8.0 and above.
  - Adjusts the `exclude` section by removing conditions related to PHP 7.4, streamlining the testing process for supported PHP versions.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rakutentech/laravel-request-docs?shareId=c3cb620c-9c3b-416e-bd60-f75ff316096b).