### PR TITLE
Fix string split on ':' only split on first 

### DIFF
--- a/ui/src/components/elements/ApiInfoRules.tsx
+++ b/ui/src/components/elements/ApiInfoRules.tsx
@@ -13,8 +13,8 @@ export default function ApiInfoRules(props: Props) {
     const StyledRule = (rule: any): JSX.Element => {
         const theRule = rule.rule
         const _tmp = theRule.split(':')
-        const split = _tmp.splice(0, 1);
-        _tmp.length && split.push(_tmp.join(':'));
+        const split = _tmp.splice(0, 1)
+        _tmp.length && split.push(_tmp.join(':'))
 
         if (theRule == 'url') {
             return (


### PR DESCRIPTION
Say the validation rule `date_format:!Y-m-d H:i:s` was used.
That would parse to the badge containing "Format: !Y-m-d H i s", stripping the required ":"'s.
This fixes that by only splitting on the first ":" and keeping the remaining string as is, including ":".