### PR TITLE
Fix path traversal vulnerability in assets endpoint

### DIFF
--- a/src/Controllers/LaravelRequestDocsController.php
+++ b/src/Controllers/LaravelRequestDocsController.php
@@ -92,40 +92,50 @@ class LaravelRequestDocsController extends Controller
         $path = explode('/', $request->path());
         $path = end($path);
         // read js, css from dist folder
-        $path = base_path() . "/vendor/rakutentech/laravel-request-docs/resources/dist/_astro/" . $path;
+        $baseDirectory = base_path() . "/vendor/rakutentech/laravel-request-docs/resources/dist/_astro";
 
-        if (file_exists($path)) {
-            $headers = ['Content-Type' => 'text/plain'];
+        // Sanitize filename and block traversal
+        $path = basename((string) $path);
 
-            // set MIME type to js module
-            if (str_ends_with($path, '.js')) {
-                $headers = ['Content-Type' => 'application/javascript'];
-            }
+        // Whitelist extensions (security hardening)
+        $allowed = [
+            'js'   => 'application/javascript',
+            'css'  => 'text/css',
+            'woff' => 'font/woff',
+            'woff2' => 'font/woff2',
+            'png'  => 'image/png',
+            'jpg'  => 'image/jpeg',
+            'jpeg' => 'image/jpeg',
+        ];
 
-            if (str_ends_with($path, '.css')) {
-                $headers = ['Content-Type' => 'text/css'];
-            }
+        $ext = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+        if ($ext === '' || !array_key_exists($ext, $allowed)) {
+            return response()->json(['error' => 'file not found'], 404);
+        }
 
-            if (str_ends_with($path, '.woff')) {
-                $headers = ['Content-Type' => 'font/woff'];
-            }
+        // Build candidate path and ensure it stays under _astro
+        $candidate = $baseDirectory . DIRECTORY_SEPARATOR . $path;
 
-            if (str_ends_with($path, '.woff2')) {
-                $headers = ['Content-Type' => 'font/woff2'];
-            }
+        $baseReal = realpath($baseDirectory);
+        $fileReal = realpath($candidate);
 
-            if (str_ends_with($path, '.png')) {
-                $headers = ['Content-Type' => 'image/png'];
-            }
+        if ($baseReal === false || $fileReal === false) {
+            return response()->json(['error' => 'file not found'], 404);
+        }
 
-            if (str_ends_with($path, '.jpg')) {
-                $headers = ['Content-Type' => 'image/jpg'];
-            }
+        $prefix = $baseReal . DIRECTORY_SEPARATOR;
+        if (strncmp($fileReal, $prefix, strlen($prefix)) !== 0) {
+            return response()->json(['error' => 'file not found'], 404);
+        }
+
+        if (is_file($fileReal)) {
+            $headers = ['Content-Type' => $allowed[$ext]];
 
             // set cache control headers
             $headers['Cache-Control'] = 'public, max-age=1800';
             $headers['Expires']       = gmdate('D, d M Y H:i:s \G\M\T', time() + 1800);
-            return response()->file($path, $headers);
+
+            return response()->file($fileReal, $headers);
         }
 
         return response()->json(['error' => 'file not found'], 404);

--- a/tests/Controllers/LaravelRequestDocsControllerTest.php
+++ b/tests/Controllers/LaravelRequestDocsControllerTest.php
@@ -17,6 +17,24 @@ use Rakutentech\LaravelRequestDocs\Tests\TestCase;
 
 class LaravelRequestDocsControllerTest extends TestCase
 {
+    private string $astroDir;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->astroDir = base_path('vendor/rakutentech/laravel-request-docs/resources/dist/_astro');
+        @mkdir($this->astroDir, 0755, true);
+        file_put_contents($this->astroDir . '/app.js', '// dummy');
+        file_put_contents($this->astroDir . '/style.css', '/* dummy */');
+    }
+
+    public function tearDown(): void
+    {
+        @unlink($this->astroDir . '/app.js');
+        @unlink($this->astroDir . '/style.css');
+        parent::tearDown();
+    }
+
     public function testApiMain(): void
     {
         // skip these tests
@@ -526,5 +544,62 @@ class LaravelRequestDocsControllerTest extends TestCase
             ->first();
 
         $this->assertSame($expected, $pathParameter);
+    }
+
+    public function testServeStaticFileReturnsJsWithCorrectHeaders(): void
+    {
+        $this->get(route('request-docs.assets', ['slug' => 'app.js']))
+            ->assertStatus(Response::HTTP_OK)
+            ->assertHeader('Content-Type', 'application/javascript')
+            ->assertHeader('Cache-Control', 'max-age=1800, public');
+    }
+
+    public function testServeStaticFileReturnsCssWithCorrectHeaders(): void
+    {
+        $this->get(route('request-docs.assets', ['slug' => 'style.css']))
+            ->assertStatus(Response::HTTP_OK)
+            ->assertHeader('Content-Type', 'text/css; charset=utf-8');
+    }
+
+    public function testDisallowedExtensionReturns404(): void
+    {
+        $this->get(route('request-docs.assets', ['slug' => 'evil.php']))
+            ->assertStatus(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testDisallowedExtensionEnvReturns404(): void
+    {
+        $this->get(route('request-docs.assets', ['slug' => '.env']))
+            ->assertStatus(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testPathTraversalReturns404(): void
+    {
+        $this->get(route('request-docs.assets', ['slug' => '../../etc/passwd']))
+            ->assertStatus(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testPathTraversalWithEncodedDotsReturns404(): void
+    {
+        $this->get(route('request-docs.assets', ['slug' => '..%2F..%2Fetc%2Fpasswd']))
+            ->assertStatus(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testNonExistentFileReturns404(): void
+    {
+        $this->get(route('request-docs.assets', ['slug' => 'nonexistent.js']))
+            ->assertStatus(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testNoExtensionReturns404(): void
+    {
+        $this->get(route('request-docs.assets', ['slug' => 'noextension']))
+            ->assertStatus(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testPathTraversalWithJsExtensionReturns404(): void
+    {
+        $this->get(route('request-docs.assets', ['slug' => '../../etc/passwd.js']))
+            ->assertStatus(Response::HTTP_NOT_FOUND);
     }
 }


### PR DESCRIPTION
## Summary
Fix a path traversal vulnerability in the `request-docs/_astro/{slug}` endpoint.

## Changes
- Sanitize filename with `basename()` to block directory traversal
- Validate resolved path with `realpath()` + `strncmp()` to ensure files stay under `_astro`
- Replace sequential `str_ends_with()` checks with an extension whitelist array mapped to MIME types

## Security
The `where` constraint at the routing layer alone could not prevent traversal with a `.js` extension (e.g. `../../etc/passwd.js`). This fix adds a second layer of protection at the controller level.

## Tests
- Happy path: verify correct response headers for `.js` and `.css` files
- Failure cases: path traversal, traversal with `.js` extension, disallowed extensions, non-existent files

### Tests results
<img width="677" height="190" alt="スクリーンショット 2026-04-16 20 20 00" src="https://github.com/user-attachments/assets/654e0ac9-a415-4020-97b4-5419f1a49540" />

> **Note:** `testApiMain` was already marked as skipped prior to this PR due to a known issue with Laravel 12 on PHP 8.4.